### PR TITLE
fix: docsRepositoryBase url in example

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -40,7 +40,7 @@ the `pages/` folder of your docs. For example:
 
 ```js
 export default {
-  docsRepositoryBase: 'https://github.com/shuding/nextra/blob/main/docs/pages'
+  docsRepositoryBase: 'https://github.com/shuding/nextra/tree/main/docs'
 }
 ```
 


### PR DESCRIPTION
The path should omit the `pages`.